### PR TITLE
feat: allow invalidating a compilation in watch mode

### DIFF
--- a/lib/observeCompilers.js
+++ b/lib/observeCompilers.js
@@ -4,42 +4,23 @@ const EventEmitter = require('events');
 
 function observeCompilers(clientCompiler, serverCompiler) {
     const eventEmitter = new EventEmitter();
-    const state = {
-        isCompiling: false,
-        beginAt: null,
-        error: null,
-        compilation: null,
-    };
+    const state = resetState({});
 
-    // Avoid NodeJS global throw if there's no error listeners
-    eventEmitter.on('error', () => {});
-
-    // Listen to compilers lifecycle events
-    clientCompiler
-    .on('begin', onBegin)
-    .on('end', onFinish)
-    .on('error', (err) => onError('client', err));
-
-    serverCompiler
-    .on('begin', onBegin)
-    .on('end', onFinish)
-    .on('error', (err) => onError('server', err));
-
-    function onBegin() {
+    const onBegin = () => {
         if (state.isCompiling) {
             return;
         }
 
         Object.assign(state, { isCompiling: true, beginAt: Date.now(), error: null, compilation: null });
         eventEmitter.emit('begin');
-    }
+    };
 
-    function onError(type, err) {
+    const onError = (type, err) => {
         err.message += ` (${type})`;
-        onFinish();
-    }
+        onEnd();
+    };
 
-    function onFinish() {
+    const onEnd = () => {
         // Wait for all compilers to be done
         if (clientCompiler.isCompiling() || serverCompiler.isCompiling()) {
             return;
@@ -68,9 +49,28 @@ function observeCompilers(clientCompiler, serverCompiler) {
             Object.assign(state, { isCompiling: false, error: null, compilation });
             eventEmitter.emit('end', compilation);
         }
-    }
+    };
+
+    // Avoid NodeJS global throw if there's no error listeners
+    eventEmitter.on('error', () => {});
+
+    // Listen to compilers lifecycle events
+    clientCompiler
+    .on('begin', onBegin)
+    .on('end', onEnd)
+    .on('error', (err) => onError('client', err));
+
+    serverCompiler
+    .on('begin', onBegin)
+    .on('end', onEnd)
+    .on('error', (err) => onError('server', err));
 
     return { eventEmitter, state };
 }
 
+function resetState(state) {
+    return Object.assign(state, { isCompiling: false, beginAt: null, error: null, compilation: null });
+}
+
 module.exports = observeCompilers;
+module.exports.resetState = resetState;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8141,9 +8141,9 @@
       }
     },
     "webpack-sane-compiler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/webpack-sane-compiler/-/webpack-sane-compiler-2.1.0.tgz",
-      "integrity": "sha512-8Yvijwk57FuVOTde2yj92ic9z+hkXfHc7iqC2hju79LDMrxa2y7cbN/FKKw67FdSdEpR+zCzoXl7Eh3z0Cy8wQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/webpack-sane-compiler/-/webpack-sane-compiler-3.0.3.tgz",
+      "integrity": "sha512-OQt++2caHlgxBF0CdG5U04Smveyuj4mjlFxqiR+POckNjkP3BJGRSZrQshV5uUV+HfH0poaUdsWhJKyB6hP6Qg==",
       "requires": {
         "lodash.wrap": "4.1.1",
         "mkdirp": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "jest --env node --coverage",
+    "posttest": "rimraf test/tmp",
     "prerelease": "npm t && npm run lint",
     "release": "standard-version",
     "precommit": "lint-staged",
@@ -51,9 +52,10 @@
     "webpack": ">=2.0.0 <4.0.0"
   },
   "dependencies": {
+    "lodash.wrap": "^4.1.1",
     "p-defer": "^1.0.0",
     "p-settle": "^2.0.0",
-    "webpack-sane-compiler": "^2.1.0"
+    "webpack-sane-compiler": "^3.0.3"
   },
   "devDependencies": {
     "@commitlint/cli": "^6.0.1",

--- a/test/unwatch.spec.js
+++ b/test/unwatch.spec.js
@@ -24,9 +24,9 @@ it('should stop watching changes (sync)', async () => {
 
     let callsCount = 0;
 
-    const unwatchPromise = compiler
-    .watch(() => { callsCount += 1; })
-    .unwatch();
+    compiler.watch(() => { callsCount += 1; });
+
+    const unwatchPromise = compiler.unwatch();
 
     await Promise.all([unwatchPromise, delay(2000)]);
 

--- a/test/util/createCompiler.js
+++ b/test/util/createCompiler.js
@@ -9,8 +9,6 @@ const webpackIsomorphicCompiler = require('../../');
 const tmpDir = path.resolve(`${__dirname}/../tmp`);
 const compilers = [];
 
-// -----------------------------------------------------------
-
 function createCompiler(clientWebpackConfig, serverWebpackConfig) {
     clientWebpackConfig = uniquifyConfig(clientWebpackConfig);
     serverWebpackConfig = uniquifyConfig(serverWebpackConfig);

--- a/test/watch.spec.js
+++ b/test/watch.spec.js
@@ -84,6 +84,26 @@ it('should output assets', (done) => {
     });
 });
 
+describe('invalidate', () => {
+    it('should return a function that can be used to invalidate and retrigger a compilation', (done) => {
+        const compiler = createCompiler(configClientBasic, configServerBasic);
+        const logEvent = jest.fn();
+
+        compiler.once('begin', () => setImmediate(() => invalidate()));
+        compiler.on('begin', () => logEvent('begin'));
+        compiler.on('invalidate', () => logEvent('invalidate'));
+        compiler.on('end', () => logEvent('end'));
+
+        const invalidate = compiler.watch(() => {
+            const loggedEvents = logEvent.mock.calls.reduce((results, [event]) => [...results, event], []);
+
+            expect(loggedEvents).toEqual(['begin', 'invalidate', 'begin', 'end']);
+
+            done();
+        });
+    });
+});
+
 describe('args', () => {
     it('should work with .watch()', (done) => {
         const compiler = createCompiler(configClientBasic, configServerBasic);


### PR DESCRIPTION
Also made some minor code style changes.

BREAKING CHANGE: `.watch` no longer returns the compiler and now returns a function that, when called, will stop an ongoing compilation and start a new one. It also emits the `invalidate` event.